### PR TITLE
Add support for Ubuntu Noble

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A read-only (no `put`) [Concourse](https://concourse.ci) resource for tracking
    * `xenial` or `ubuntu-16.04-lts` for Ubuntu Xenial
    * `bionic` or `ubuntu-18.04-lts` for Ubuntu Bionic
    * `jammy`  or `ubuntu-22.04-lts` for Ubuntu Jammy
+   * `noble`  or `ubuntu-24.04-lts` for Ubuntu Noble
    * ... (see filters on the USN website for more)
  * `priorities` - list of CVE priorities to trigger on
    * `medium`

--- a/api/integration_test.go
+++ b/api/integration_test.go
@@ -56,7 +56,7 @@ var _ = Describe("CVE", func() {
 	})
 
 	It("parses a USN for releases affected", func() {
-		usn := api.USN{URL: "https://ubuntu.com/security/notices/USN-4653-1"}
-		Expect(usn.IsForRelease("xenial")).To(BeTrue())
+		usn := api.USN{URL: "https://ubuntu.com/security/notices/USN-6912-1"}
+		Expect(usn.IsForRelease("noble")).To(BeTrue())
 	})
 })

--- a/api/usn.go
+++ b/api/usn.go
@@ -41,6 +41,7 @@ var lineToName = map[string]string{
 	"ubuntu-16.04-lts": "xenial",
 	"ubuntu-18.04-lts": "bionic",
 	"ubuntu-22.04-lts": "jammy",
+	"ubuntu-24.04-lts": "noble",
 }
 
 func USNFromFeed(item *gofeed.Item) *USN {


### PR DESCRIPTION
- stop using `xenial` in specs