### PR TITLE
add source config for ignoring cache

### DIFF
--- a/api/oval_usn.go
+++ b/api/oval_usn.go
@@ -150,7 +150,7 @@ func ParseOvalData(xml []byte) (OvalDefinitions, error) {
 	return ovalDefinitions, nil
 }
 
-func GetOvalRawData(osStr string) ([]byte, error) {
+func GetOvalRawData(osStr string, ignoreCache bool) ([]byte, error) {
 	val, ok := lineToName[osStr]
 	if ok {
 		osStr = val
@@ -164,7 +164,7 @@ func GetOvalRawData(osStr string) ([]byte, error) {
 	etag := resp.Header.Get("etag")
 
 	existingEtag, _ := os.ReadFile(ETagPath) //nolint:errcheck
-	if etag == string(existingEtag) && etag != "" {
+	if etag == string(existingEtag) && etag != "" && !ignoreCache {
 		fmt.Fprintf(os.Stderr, "Using cached oval file based on etag %s\n", etag) //nolint:errcheck
 		existingOvalData, err := os.ReadFile(CachedOvalXMLPath)
 		if err != nil {

--- a/api/types.go
+++ b/api/types.go
@@ -1,9 +1,10 @@
 package api
 
 type Source struct {
-	OS         string   `json:"os"`
-	Priorities []string `json:"priorities"`
-	Severities []string `json:"severities"`
+	OS          string   `json:"os"`
+	Priorities  []string `json:"priorities"`
+	Severities  []string `json:"severities"`
+	IgnoreCache bool     `json:"ignore_cache"`
 }
 
 type Version struct {

--- a/check/main.go
+++ b/check/main.go
@@ -18,7 +18,7 @@ func main() {
 	if err != nil {
 		log.Fatal("check: bad stdin: parse error", err)
 	}
-	rawData, err := api.GetOvalRawData(request.Source.OS)
+	rawData, err := api.GetOvalRawData(request.Source.OS, request.Source.IgnoreCache)
 	if err != nil {
 		log.Fatalf("check: error retreiving oval data: '%s'", err)
 	}

--- a/in/main.go
+++ b/in/main.go
@@ -50,7 +50,7 @@ func main() {
 		return
 	}
 
-	rawData, err := api.GetOvalRawData(request.Source.OS)
+	rawData, err := api.GetOvalRawData(request.Source.OS, request.Source.IgnoreCache)
 	if err != nil {
 		log.Fatalf("in: error retreiving oval data: '%s'", err)
 	}


### PR DESCRIPTION
* I've seen some issues where the data from the canonical endpoint can have the same timestamp and etag, but different content
* I wanted an option to ignore the cache for debugging.
* I opted for the field to default false, so that it shouldn't break anything existing.
* I also opted for it to just ignore reading the cache, but continue writing to it. The intent was to make it more seamless when you go back to using the cache, though tbh the current caching logic should cover that case anyway.